### PR TITLE
Allow passing of multiple root folders into browser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,6 @@ module.exports = {
     "rules": {
         "accessor-pairs": "error",
         "array-bracket-newline": "error",
-        "array-bracket-spacing": "error",
         "array-callback-return": "error",
         "array-element-newline": "error",
         "arrow-body-style": "error",
@@ -76,7 +75,6 @@ module.exports = {
         "max-lines": "error",
         "max-lines-per-function": "error",
         "max-nested-callbacks": "error",
-        "max-params": "error",
         "max-statements": "off",
         "max-statements-per-line": "off",
         "multiline-comment-style": "error",

--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,15 @@ const path = require('path');
 const fb = require('./index.js');
 
 fb.configure({
-    removeLockString: true
+    removeLockString: true,
+
+    /*
+     * Example of otherRoots.
+     * The other roots are listed and displayed, but their
+     * locations need to be calculated by the server.
+     * See OTHERROOTS in the app.
+     */
+    otherRoots: [ '/tmp' ]
 });
 
 function checkValidity(argv) {
@@ -37,7 +45,17 @@ const app = express();
 
 var dir =  process.cwd();
 app.get('/b', function(req, res) {
-    let file = path.join(dir,req.query.f);
+    let file;
+    if (req.query.r === '/tmp') {
+
+        /*
+         * OTHERROOTS
+         * This is an example of a manually calculated path.
+         */
+        file = path.join(req.query.r,req.query.f);
+    } else {
+        file = path.join(dir,req.query.f);
+    }
     res.sendFile(file);
 })
 

--- a/index.js
+++ b/index.js
@@ -63,6 +63,11 @@ function displayFiles(err, files, currentDir, query) {
     return data;
 }
 
+/*
+ * readRoots: read the list of files in a list of roots.
+ * This is a recursive function, calling itself in
+ * the readdir() callback until the list is iterated through.
+ */
 function readRoots(roots, res, query, fullList) {
     let currentDir = roots.shift();
 
@@ -70,6 +75,7 @@ function readRoots(roots, res, query, fullList) {
         let data = fullList.concat(displayFiles(err, files, currentDir, query));
 
         if (roots.length > 0) {
+            // loop to the next element
             readRoots(roots, res, query, data);
         } else {
             res.json(_.sortBy(data, function(f) { return f.Name }));

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ let exclude;
 
 // default configuration
 let config = {
-    removeLockString: false
+    removeLockString: false,
+    otherRoots: []
 };
 
 exports.moduleroot = __dirname;
@@ -19,29 +20,25 @@ exports.setcwd = function(cwd, inc, exc) {
     exclude = exc;
 }
 
-exports.get = function(req, res) {
- let currentDir =  dir;
- let query = req.query.path || '';
- if (query) currentDir = path.join(dir, query);
- fs.readdir(currentDir, function (err, files) {
-     if (err) {
+function displayFiles(err, files, currentDir, query) {
+    if (err) {
         throw err;
-      }
-      let data = [];
-      files
-      .filter(function () {
-          return true;
-      })
-      .forEach(function (file) {
-        let isDirectory = fs.statSync(path.join(currentDir,file)).isDirectory();
+    }
+    let data = [];
+    files.forEach(function (file) {
+        let isDirectory =
+            fs.statSync(path.join(currentDir, file)).isDirectory();
         if (isDirectory) {
-            data.push({ Name : file, IsDirectory: true, Path : path.join(query, file)  });
+            data.push({
+                Name : file,
+                IsDirectory: true,
+                Path : path.join(query, file)
+            });
         } else {
-            var ext = path.extname(file);
+            let ext = path.extname(file);
             if(exclude && _.contains(exclude, ext)) {
                 return;
-            }
-            else if(include && !_.contains(include, ext)) {
+            } else if(include && !_.contains(include, ext)) {
                 return;
             }
             let filestr;
@@ -50,17 +47,49 @@ exports.get = function(req, res) {
             } else {
                 filestr = file;
             }
+            let rstr = '';
+            if (currentDir !== dir) {
+                rstr = currentDir;
+            }
             data.push({
                 Name : filestr,
                 Ext : ext,
                 IsDirectory: false,
-                Path : path.join(query, file)
+                Path : path.join(query, file),
+                Root : rstr
             });
         }
-      });
-      data = _.sortBy(data, function(f) { return f.Name });
-      res.json(data);
-  });
+    });
+    return data;
+}
+
+function readRoots(roots, res, query, fullList) {
+    let currentDir = roots.shift();
+
+    fs.readdir(currentDir, function (err, files) {
+        let data = fullList.concat(displayFiles(err, files, currentDir, query));
+
+        if (roots.length > 0) {
+            readRoots(roots, res, query, data);
+        } else {
+            res.json(_.sortBy(data, function(f) { return f.Name }));
+        }
+    });
+
+}
+
+exports.get = function(req, res) {
+    let currentDir =  dir;
+    let query = req.query.path || '';
+    let roots = [];
+    if (query) {
+        roots.push(path.join(dir, query));
+    } else {
+        // top level, add all roots
+        roots = config.otherRoots.slice();
+        roots.push(currentDir);
+    }
+    readRoots(roots, res, query, []);
 };
 
 exports.configure = function(c) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -63,7 +63,11 @@
                        "<i class='fa fa-folder'></i>&nbsp;" +
                        data.Name +"</a>";
               } else {
-                return "<a href='/b?f=" + data.Path +
+                let rstr = '';
+                if (data.Root) {
+                    rstr = 'r=' + data.Root + '&';
+                }
+                return "<a href='/b?" + rstr + "f=" + data.Path +
                        "' target='_blank'><i class='fa " +
                        getFileIcon(data.Ext) + "'></i>&nbsp;" +
                        data.Name +"</a>";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "file-browser",
   "author": "David Dombrowsky",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "file-browser allows embedding of a web-enabled file browser in your node site",
   "keywords": [
     "filebrowser",


### PR DESCRIPTION
Some systems require the "root" to be logical, while the underlying files exist in two separate directories. 

For example, a system might have:
* static content in an asar file, so the root would be `/path/to/stuff.asar`
* streamable content in a directory, so the additional root would be `/path/to/streamable/`

The server will have to handle differentiating the requests.  There is an example in `cli.js`.