### PR TITLE
tolerate non-existent roots in browser

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -14,7 +14,7 @@ fb.configure({
      * locations need to be calculated by the server.
      * See OTHERROOTS in the app.
      */
-    otherRoots: [ '/tmp' ]
+    otherRoots: [ '/tmp', '/broken' ]
 });
 
 function checkValidity(argv) {

--- a/index.js
+++ b/index.js
@@ -20,10 +20,7 @@ exports.setcwd = function(cwd, inc, exc) {
     exclude = exc;
 }
 
-function displayFiles(err, files, currentDir, query) {
-    if (err) {
-        throw err;
-    }
+function displayFiles(files, currentDir, query) {
     let data = [];
     files.forEach(function (file) {
         let isDirectory =
@@ -72,7 +69,13 @@ function readRoots(roots, res, query, fullList) {
     let currentDir = roots.shift();
 
     fs.readdir(currentDir, function (err, files) {
-        let data = fullList.concat(displayFiles(err, files, currentDir, query));
+        let data;
+        if (err) {
+            // ignore non-readable directories
+            data = fullList;
+        } else {
+            data = fullList.concat(displayFiles(files, currentDir, query));
+        }
 
         if (roots.length > 0) {
             // loop to the next element

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "file-browser",
   "author": "David Dombrowsky",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "file-browser allows embedding of a web-enabled file browser in your node site",
   "keywords": [
     "filebrowser",


### PR DESCRIPTION
tolerate non-existent roots in browser

This allows us to use a folder as a separate root, which may or may not exist.